### PR TITLE
Fix a warning due to use of undefined variable.

### DIFF
--- a/CustomReporter.php
+++ b/CustomReporter.php
@@ -40,7 +40,7 @@ class CustomReporterPlugin extends MantisPlugin {
 				</td>
 				<td width="70%">
 					<select <?php echo helper_get_tab_index() ?> name="reporter_id">
-						<?php print_reporter_option_list( $t_user_id, $p_new_bug->project_id ) ?>
+						<?php print_reporter_option_list( $t_user_id, $p_project_id ) ?>
 					</select>
 				</td>
 			</tr>


### PR DESCRIPTION
The plugin was using $p_new_bug->project_id instead of $p_project_id.
