### PR TITLE
Simultaneous support for Mantis 1.2/1.3.

### DIFF
--- a/CustomReporter.php
+++ b/CustomReporter.php
@@ -7,7 +7,7 @@ class CustomReporterPlugin extends MantisPlugin {
 		$this->description = lang_get( 'plugin_customreporter_description' );
 		$this->page = 'config';
 		$this->version = '1.03';
-		$this->requires = array( 'MantisCore' => '1.2.0', );
+		$this->requires = array( 'MantisCore' => '1.2.0, < 1.4', );
 		$this->author = 'Carlos Proensa, Cas Nuy, Damien Regad';
 		$this->contact = '';
 		$this->url = '';
@@ -33,18 +33,35 @@ class CustomReporterPlugin extends MantisPlugin {
 		$t_access_level = user_get_access_level( $t_user_id, $p_project_id );
 
 		if ( $t_access_level >= plugin_config_get( 'select_threshold' ) ) {
+			if (substr(MANTIS_VERSION, 0, 3) == "1.3")
+			{		
 ?>		    
-			<tr <?php echo helper_alternate_class() ?>>
-				<td class="category" width="30%">
-					<?php echo lang_get( 'reporter' ) ?>
-				</td>
-				<td width="70%">
-					<select <?php echo helper_get_tab_index() ?> name="reporter_id">
-						<?php print_reporter_option_list( $t_user_id, $p_project_id ) ?>
-					</select>
-				</td>
-			</tr>
+				<div class="field-container">
+					<label><span><?php echo lang_get( 'reporter' ) ?></span></label>
+					<span class="input">
+						<select <?php echo helper_get_tab_index() ?> name="reporter_id">
+							<?php print_reporter_option_list( $t_user_id, $p_project_id ) ?>
+						</select>
+					</span>
+					<span class="label-style"></span>
+				</div>
 <?php
+			}
+			elseif (substr(MANTIS_VERSION, 0, 3) == "1.2")
+			{				
+?>		
+				<tr <?php echo helper_alternate_class() ?>>
+					<td class="category" width="30%">
+						<?php echo lang_get( 'reporter' ) ?>
+					</td>
+					<td width="70%">
+						<select <?php echo helper_get_tab_index() ?> name="reporter_id">
+							<?php print_reporter_option_list( $t_user_id, $p_project_id ) ?>
+						</select>
+					</td>
+				</tr>
+<?php
+			}
 		}
 	}
 

--- a/CustomReporter.php
+++ b/CustomReporter.php
@@ -7,7 +7,7 @@ class CustomReporterPlugin extends MantisPlugin {
 		$this->description = lang_get( 'plugin_customreporter_description' );
 		$this->page = 'config';
 		$this->version = '1.03';
-		$this->requires = array( 'MantisCore' => '1.2.0, < 1.4', );
+		$this->requires = array( 'MantisCore' => '1.3.0', );
 		$this->author = 'Carlos Proensa, Cas Nuy, Damien Regad';
 		$this->contact = '';
 		$this->url = '';
@@ -33,35 +33,17 @@ class CustomReporterPlugin extends MantisPlugin {
 		$t_access_level = user_get_access_level( $t_user_id, $p_project_id );
 
 		if ( $t_access_level >= plugin_config_get( 'select_threshold' ) ) {
-			if (substr(MANTIS_VERSION, 0, 3) == "1.3")
-			{		
 ?>		    
-				<div class="field-container">
-					<label><span><?php echo lang_get( 'reporter' ) ?></span></label>
-					<span class="input">
-						<select <?php echo helper_get_tab_index() ?> name="reporter_id">
-							<?php print_reporter_option_list( $t_user_id, $p_project_id ) ?>
-						</select>
-					</span>
-					<span class="label-style"></span>
-				</div>
+			<div class="field-container">
+				<label><span><?php echo lang_get( 'reporter' ) ?></span></label>
+				<span class="input">
+					<select <?php echo helper_get_tab_index() ?> name="reporter_id">
+						<?php print_reporter_option_list( $t_user_id, $p_project_id ) ?>
+					</select>
+				</span>
+				<span class="label-style"></span>
+			</div>
 <?php
-			}
-			elseif (substr(MANTIS_VERSION, 0, 3) == "1.2")
-			{				
-?>		
-				<tr <?php echo helper_alternate_class() ?>>
-					<td class="category" width="30%">
-						<?php echo lang_get( 'reporter' ) ?>
-					</td>
-					<td width="70%">
-						<select <?php echo helper_get_tab_index() ?> name="reporter_id">
-							<?php print_reporter_option_list( $t_user_id, $p_project_id ) ?>
-						</select>
-					</td>
-				</tr>
-<?php
-			}
 		}
 	}
 


### PR DESCRIPTION
A proposed change in order to natively support versions 1.2 and 1.3 without having to modify the plugin for each installation. Mantis 1.3 now uses styled form elements instead of tables, so the CustomReporter box does not properly display on 1.3.

* Considering that the first 2 numbers in MANTIS_VERSION are expected to follow the same format, it is easy to selectively show the proper markup to display the dropdown.
* Also, adding the < 1.4 ensures that the plugin will be allowed to be installed in 1.2 and 1.3 without having to change.

Thank you for this plugin, it is very useful!